### PR TITLE
Add "project values" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The core PureScript GitHub organization exists to maintain and develop:
 *   Documentation
 *   Package Sets
 
+# Project Values
+
+- PureScript is industrially focused; it is not a vehicle for programming language research. Consequently, stability is a high priority. Feature requests which have a large impact on downstream code are unlikely to be accepted.
+- Prefer fewer, more powerful features to many special-purpose ones. With a smaller feature set, things are easier to document, the implementation is easier to understand and work with, and features are less likely to interact poorly with one another.
+- Prefer to move slowly and consider decisions carefully, especially if they are likely to have a long-term impact.
+- If it is possible to adequately solve a need downstream of the compiler and/or core libraries, we are unlikely to add features for solving that need inside the compiler and/or core libraries.
+
 # Core Owners
 
 Organization ownership is primarily predicated on having commit access to the


### PR DESCRIPTION
I've tried to distil points raised from discussion in #1, my own perspective, and also Phil's [discourse post on the same topic](https://discourse.purescript.org/t/the-principles-of-purescript/163) into a set of project values which we can point contributors to to better set expectations and give people an idea of where the project is heading. What do people think of this?