### PR TITLE
Expanding on roles and decision making

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ following ways (or however else they see fit):
 *   Sending PRs
 *   Reviewing PRs
 
+### Role Changes
+
+*   Core owners may choose to step down and leave the organization at any time.
+*   Core collaborators may be promoted to owners at the discretion of the rest of the owners.
+
 ## Making Decisions
 
 Most decisions which directly concern the language, compiler, or core libraries

--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ Core owners have demonstrated a long-term commitment to maintaining the
 compiler, maintaining the standard library, and engaging with the language
 community as a whole.
 
-Core collaborators may be promoted to owners at the discretion of the rest of
-the owners. Core owners may choose to step down and leave the organization at
-any time.
-
 Core owners are expected to use their privileges responsibly, in order to guide
 the development of the language, compiler, and core libraries in a way that
 they feel best serves the community as a whole.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,43 @@
-# Purpose
+# PureScript governance
 
-The core PureScript GitHub organization exists to maintain and develop:
+## Purpose
 
-*   The PureScript language (as defined by the implementation in the `purescript` compiler project).
-*   The PureScript standard library (`purescript-*` projects).
-*   The PureScript website infrastructure (purescript.org, Try PureScript, Pursuit)
+The core PureScript GitHub organization (<https://github.com/purescript>)
+exists to maintain and develop:
+
+*   The PureScript language (as defined by the implementation in the compiler
+    repository, `purescript/purescript`), and the compiler itself
+*   The PureScript core libraries (that is, the libraries under the
+    `purescript` org on GitHub)
+*   The PureScript website infrastructure (purescript.org, Try PureScript,
+    Pursuit)
 *   Documentation
 *   Package Sets
 
-# Project Values
+## Project Values
 
-- PureScript is industrially focused; it is not a vehicle for programming language research. Consequently, stability is a high priority. Feature requests which have a large impact on downstream code are unlikely to be accepted.
-- Prefer fewer, more powerful features to many special-purpose ones. With a smaller feature set, things are easier to document, the implementation is easier to understand and work with, and features are less likely to interact poorly with one another.
-- Prefer to move slowly and consider decisions carefully, especially if they are likely to have a long-term impact.
-- If it is possible to adequately solve a need downstream of the compiler and/or core libraries, we are unlikely to add features for solving that need inside the compiler and/or core libraries.
+*   PureScript is industrially focused; it is not a vehicle for programming
+    language research. Consequently, stability is a high priority. Feature
+    requests which have a large impact on downstream code are unlikely to be
+    accepted.
+*   Prefer fewer, more powerful features to many special-purpose ones. With a
+    smaller feature set, things are easier to document, the implementation is
+    easier to understand and work with, and features are less likely to
+    interact poorly with one another.
+*   Prefer to move slowly and consider decisions carefully, especially if they
+    are likely to have a long-term impact.
+*   If it is possible to adequately solve a need downstream of the compiler
+    and/or core libraries, we are unlikely to add features for solving that
+    need inside the compiler and/or core libraries.
 
-# Core Owners
+## Roles
 
-Organization ownership is primarily predicated on having commit access to the
-core compiler. Since the language is defined by its implementation, this
-project and associated responsibilities are what largely shape its direction
-and development.
+### Core Owners
+
+The core organization owners lead the development of the language, compiler,
+and core libraries. Since the language is defined by its implementation, the
+compiler project and associated responsibilities are what largely shape its
+direction and development.
 
 The core organization owners are:
 
@@ -31,11 +48,25 @@ The core organization owners are:
 *   Hardy Jones (@joneshf)
 *   Nathan Faubion (@natefaubion)
 
-Owners have demonstrated a long-term commitment to maintaining the compiler,
-maintaining the standard library, and engaging with the language community as
-a whole.
+Core owners have demonstrated a long-term commitment to maintaining the
+compiler, maintaining the standard library, and engaging with the language
+community as a whole.
 
-# Core Collaborators
+Core collaborators may be promoted to owners at the discretion of the rest of
+the owners. Core owners may choose to step down and leave the organization at
+any time.
+
+Core owners are expected to use their privileges responsibly, in order to guide
+the development of the language, compiler, and core libraries in a way that
+they feel best serves the community as a whole.
+
+Core ownership is not predicated on responding to issues or pull requests in
+any given timeframe; core owners may choose to involve themselves in the
+development of the language, compiler, and libraries to whatever extent they
+wish to. The reasoning for this is that we don't want any given maintainer to
+feel pressured to do things that their life and schedules don't permit.
+
+### Core Collaborators
 
 Core owners may extend commit access on a project basis to those that have
 expressed interest in maintaining a subset of the organization. Collaborators
@@ -45,3 +76,44 @@ include:
 *   Thomas Honeyman (@thomashoneyman) - Infrastructure
 *   Justin Woo (@justinwoo) - Package Sets
 *   Fabrizio Ferrai (@f-f) - Package Sets
+
+Collaborators are encouraged to help out with maintenance in any of the
+following ways (or however else they see fit):
+
+*   Merging PRs if they are ready to be merged (see below)
+*   Managing the issue tracker (labelling, closing, or otherwise tidying up
+    issues)
+*   Discussing proposed features or bug reports
+*   Sending PRs
+*   Reviewing PRs
+
+## Making Decisions
+
+Most decisions which directly concern the language, compiler, or core libraries
+should receive the approval of the core owners. For example, this would apply
+to:
+
+*   Feature requests
+*   Concerns raised during pull request review
+*   Adding new collaborators
+*   Promoting collaborators to owners
+
+For a decision to be made, it should receive the approval of all core owners
+who choose to participate in the discussion. In essence, every core owner has a
+veto (which they are expected to use responsibly).
+
+Not all core owners are required to participate in every discussion -- it is
+expected that most discussions will only involve a subset of the core owners.
+Before any particular decision is finalized, sufficient time should be given so
+that people have an opportunity to object, especially for decisions which would
+be difficult to reverse later.
+
+Core owners have the final say in decisions, although they are expected to be
+receptive to the needs of the wider community.
+
+## Pull Requests
+
+Pull requests on the compiler and core library repositories should receive
+approving code reviews from at least two core owners before merging. For pull
+requests which have been made by core owners, only one other core owner's
+approval is required.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ to:
 *   Concerns raised during pull request review
 *   Adding new collaborators
 *   Promoting collaborators to owners
+*   Changes to governance
 
 For a decision to be made, it should receive the approval of all core owners
 who choose to participate in the discussion. In essence, every core owner has a

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ following ways (or however else they see fit):
 
 ### Role Changes
 
-*   Core owners may choose to step down and become core collaborators, or choose leave to leave the organization entirely, at any time.
+*   Core owners may choose to step down and become core collaborators, or choose to leave the organization entirely, at any time.
 *   Core collaborators may be promoted to owners at the discretion of the rest of the owners.
 
 ## Making Decisions

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ following ways (or however else they see fit):
 
 ### Role Changes
 
-*   Core owners may choose to step down and leave the organization at any time.
+*   Core owners may choose to step down and become core collaborators, or choose leave to leave the organization entirely, at any time.
 *   Core collaborators may be promoted to owners at the discretion of the rest of the owners.
 
 ## Making Decisions
@@ -108,7 +108,11 @@ Not all core owners are required to participate in every discussion -- it is
 expected that most discussions will only involve a subset of the core owners.
 Before any particular decision is finalized, sufficient time should be given so
 that people have an opportunity to object, especially for decisions which would
-be difficult to reverse later.
+be difficult to reverse later. In general, the length of time that is
+considered "sufficient" depends on the magnitude of the decision, and core
+owners are expected to use their judgement. If a month has passed since the
+first approval by a core owner, and no other core owners have objected in that
+time, a decision can always be considered to have been approved.
 
 Core owners have the final say in decisions, although they are expected to be
 receptive to the needs of the wider community.


### PR DESCRIPTION
See also #1. This PR mostly aims to document what the current roles and
processes for decision making and getting things merged are, so that
they will be clearer to the wider community. That is, most of what I
have written here is intended to describe the current model (rather than
prescribe a new model).

Unlike in #1, I haven't described a "Language Supporter" role: in order
to keep this PR small, I would prefer to focus just on people who have
commit access to the compiler and/or core libraries for now.

There is also a part of this PR which does (sort of) represent a change
in the governance model, however. I would also like to start giving
commit access (i.e. "core collaborator" status) to some people on the
compiler repository. Up until now, we haven't done this at all; everyone
who has commit access on the compiler repository is currently a "core
owner".

I would like to add more core collaborators because we are a little
overstretched: we are not recruiting new maintainers at a very high
rate, and I think there is a bit too much going on for us (i.e. the
current core team) to be able to comfortably keep up with right now.

I think the main barrier to offering more people commit access on the
compiler repo right now is that it is not entirely clear what would be
expected of them. With the changes in this PR, I hope to make
expectations clear, so that we can start adding people as core
collaborators for the compiler repository, and so that these people will
feel empowered to help out without worrying about overstepping
expectations.

Finally, there are also some changes to make the formatting of this
document more consistent, and some minor clarifications (e.g. in the
Purpose section).