### PR TITLE
Create REGISTRY_TRUSTEES.md

### DIFF
--- a/REGISTRY_TRUSTEES.md
+++ b/REGISTRY_TRUSTEES.md
@@ -1,0 +1,8 @@
+The [PureScript Registry](https://github.com/purescript/registry) stores PureScript packages and makes them available to package managers. The registry is mostly automated, but circumstances occasionally call for manual intervention. In these cases, the registry trustees are the only authorized people to make adjustments. The scope of their powers is [described in the registry spec](https://github.com/purescript/registry/#Registry-Trustees).
+
+Trustees are appointed by the core team and can be removed by the core team.
+
+## Current Trustees
+
+- Fabrizio Ferrai ([@f-f](https://github.com/f-f))
+- Thomas Honeyman ([@thomashoneyman](https://github.com/thomashoneyman))


### PR DESCRIPTION
This creates an initial REGISTRY_TRUSTEES file that can be linked to from the under-development [registry spec](https://github.com/purescript/registry/blob/master/SPEC.md). Registry trustees are appointed by the core team, and so it makes sense that the trustees list is kept somewhere only the core team has access (hence the choice of this repository).

Trustees are not yet in effect because the registry hasn't launched, but I'm adding this document here just to lay the groundwork for when it _does_ launch.