### PR TITLE
Add @PureFunctor to core collaborators

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ include:
 *   Colin Wahl ([@colinwahl](https://github.com/colinwahl)) - Registry, Spago
 *   Miles Frain ([@milesfrain](https://github.com/milesfrain)) - Book
 *   Mike Solomon ([@mikesol](https://github.com/mikesol)) - Survey
+*   Justin Garcia ([@PureFunctor](https://github.com/purefunctor)) - Compiler
 
 Collaborators are encouraged to help out with maintenance in any of the
 following ways (or however else they see fit):


### PR DESCRIPTION
This adds @PureFunctor to the core collaborators for the compiler. @PureFunctor, please let me know if you would like anything changed about how your name and handle are displayed here.